### PR TITLE
Several Improvements to partial requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,18 +268,17 @@ Resources that implement Ranger can handle requests with a `Range` header and re
 type Doc []byte
 // assuming Doc implements rst.Resource interface
 
+// Supported units will be displayed in the Accept-Range header
+func (d *Doc) Units() []string {
+    return []string{"bytes"}
+}
+
 // Count returns the total number of range units available
 func (d *Doc) Count() uint64 {
 	return uint64(len(d))
 }
 
 func (d *Doc) Range(rg *rst.Range) (*rst.ContentRange, rst.Resource, error) {
-	if rg.Unit != "bytes" {
-		// the Range header is ignored if the range unit passed is not bytes.
-		// Request will be processed like a normal HTTP Get request because
-		// ErrUnsupportedRangeUnit is returned.
-		return nil, nil, ErrUnsupportedRangeUnit
-	}
 	cr := &ContentRange{rg, c.Count()}
 	part := d[rg.From : rg.To+1]
 	return cr, part, nil

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ A resource can implement the [Ranger](#ranger) interface to gain the ability to 
 
 `Ranger.Range` method will be called when a valid `Range` header is found in an incoming `GET` request.
 
+The `Accept-Range` header will be inserted automatically.
+
+The supported range units and the range extent will be validated for you.
+
 Note that the `If-Range` conditional header is supported as well.
 
 ### CORS

--- a/errors.go
+++ b/errors.go
@@ -72,7 +72,7 @@ func PreconditionFailed() *Error {
 }
 
 // UnsupportedMediaType is returned when the entity in the request is in a format
-// no support by the server. The supported media MIME type strings can be passed
+// not support by the server. The supported media MIME type strings can be passed
 // to improve the description of the error description.
 func UnsupportedMediaType(mimes ...string) *Error {
 	description := "The entity in the request is in a format not supported by this resource."
@@ -95,11 +95,7 @@ func RequestedRangeNotSatisfiable(cr *ContentRange) *Error {
 		http.StatusText(http.StatusRequestedRangeNotSatisfiable),
 		"The requested range is not available and cannot be served.",
 	)
-	if cr.Total == 0 {
-		err.Header.Set("Content-Range", "*/*")
-	} else {
-		err.Header.Set("Content-Range", fmt.Sprintf("%s */%d", cr.Unit, cr.Total))
-	}
+	err.Header.Set("Content-Range", cr.String())
 	err.Header.Add("Vary", "Range")
 	return err
 }

--- a/handlers.go
+++ b/handlers.go
@@ -210,11 +210,16 @@ func (f getFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if resource is a Ranger, and the request contains a valid Range
-	// header
-	rg, err := ParseRange(r.Header.Get("Range"))
+	// Check if resource implements Ranger
 	ranger, implemented := resource.(Ranger)
-	if !implemented || err != nil {
+	if !implemented {
+		writeResource(resource, w, r)
+		return
+	}
+
+	// Check if request contains a valid Range header
+	rg, err := ParseRange(r.Header.Get("Range"))
+	if err != nil {
 		writeResource(resource, w, r)
 		return
 	}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -252,7 +252,7 @@ func TestPartialGetNotSatisfiableHandler(t *testing.T) {
 		if err := rr.TestStatusCode(http.StatusRequestedRangeNotSatisfiable); err != nil {
 			t.Fatal(err)
 		}
-		if err := rr.TestHeader("Content-Range", fmt.Sprintf("resources */%d", len(testPeopleResourceCollection))); err != nil {
+		if err := rr.TestHeader("Content-Range", fmt.Sprintf("*/%d", len(testPeopleResourceCollection))); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/headers_test.go
+++ b/headers_test.go
@@ -41,7 +41,7 @@ func TestParseRange(t *testing.T) {
 func TestAcceptAdjust(t *testing.T) {
 	from, to := uint64(15), uint64(100000)
 	rg := &Range{"resources", from, to}
-	rg.Adjust(testPeopleResourceCollection)
+	rg.adjust(testPeopleResourceCollection)
 
 	if from != rg.From {
 		t.Fatal("from did not match. Got:", rg.From, "Wanted:", from)

--- a/rst.go
+++ b/rst.go
@@ -129,6 +129,10 @@ header automatically inserted.
 Ranger.Range method will be called when a valid Range header is found in an
 incoming GET request.
 
+The Accept-Range header will be inserted automatically.
+
+The supported range units and the range extent will be validated for you.
+
 Note that the If-Range conditional header is supported as well.
 
 CORS

--- a/service_test.go
+++ b/service_test.go
@@ -98,10 +98,11 @@ func (c resourceCollection) Count() uint64 {
 	return uint64(len(c))
 }
 
+func (c resourceCollection) Units() []string {
+	return []string{"bytes", "resources"}
+}
+
 func (c resourceCollection) Range(rg *Range) (*ContentRange, Resource, error) {
-	if rg.Unit == "unsupported" {
-		return nil, nil, ErrUnsupportedRangeUnit
-	}
 	return &ContentRange{rg, c.Count()}, c[rg.From : rg.To+1], nil
 }
 
@@ -268,6 +269,7 @@ func TestMain(m *testing.M) {
 	}
 
 	testMux = NewMux()
+	testMux.Debug = true
 	testMux.Handle("/echo", EndpointHandler(&echoEndpoint{}))
 	testMux.Handle("/panic", EndpointHandler(&panicEndpoint{}))
 	testMux.Handle("/people", EndpointHandler(&peopleCollection{}))


### PR DESCRIPTION
- Range header is no longer parsed before ensuring that Ranger is implemented
- Ranger now requires a `Units()` method to define the supported range units for the given resource;
- `Accept-Range` header now automatically inserted in responses when Ranger is implemented;
- `Range.Adjust` and `ErrUnsupportedRange` are no longer publicly exposed; 
- Automatic `Range` header unit validation;
- Fixed the `Content-Range` string for status code 416.