### PR TITLE
Resources can now implement http.Handler

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -193,6 +193,12 @@ func (e *Error) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Remove headers which might have been set by a previous assumption of
+	// success.
+	w.Header().Del("Last-Modified")
+	w.Header().Del("ETag")
+	w.Header().Del("Expires")
+
 	w.Header().Set("Content-Type", ct)
 	w.Header().Add("Vary", "Accept")
 	if e.Code != http.StatusNotFound && e.Code != http.StatusGone {

--- a/errors.go
+++ b/errors.go
@@ -11,6 +11,15 @@ import (
 	"strings"
 )
 
+// ErrorHandler is a wrapper that allows any Go error to implement the
+// http.Handler interface.
+func ErrorHandler(err error) http.Handler {
+	if e, ok := err.(*Error); ok {
+		return e
+	}
+	return InternalServerError(err.Error(), "", false)
+}
+
 // BadRequest is returned when the request could not be understood by the
 // server due to malformed syntax.
 func BadRequest(reason, description string) *Error {

--- a/handlers.go
+++ b/handlers.go
@@ -83,16 +83,7 @@ type Ranger interface {
 }
 
 func writeError(e error, w http.ResponseWriter, r *http.Request) {
-	if err, valid := e.(*Error); valid {
-		err.ServeHTTP(w, r)
-		return
-	}
-	err := NewError(
-		http.StatusInternalServerError,
-		http.StatusText(http.StatusInternalServerError),
-		e.Error(),
-	)
-	err.ServeHTTP(w, r)
+	ErrorHandler(e).ServeHTTP(w, r)
 }
 
 func writeResource(resource Resource, w http.ResponseWriter, r *http.Request) {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -73,6 +73,22 @@ func TestAllowedMethods(t *testing.T) {
 	}
 }
 
+func TestResourceHTTPHandlerInterface(t *testing.T) {
+	rr := newRequestResponse(Post, testServerAddr+"/chunked", nil, bytes.NewReader(testMBText))
+	if err := rr.TestStatusCode(http.StatusOK); err != nil {
+		t.Fatal(err)
+	}
+	if err := rr.TestHasHeader("Last-Modified"); err != nil {
+		t.Fatal(err)
+	}
+	if err := rr.TestHasHeader("Etag"); err != nil {
+		t.Fatal(err)
+	}
+	if err := rr.TestHasHeader("Expires"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestGetMethodHandler(t *testing.T) {
 	var test = func(method string, header http.Header, expected reflect.Type) {
 		all := &allInterfaces{}
@@ -123,7 +139,15 @@ func TestGetHandler(t *testing.T) {
 		if err := rr.TestHeader("Content-Type", header.Get("Accept")); err != nil {
 			t.Fatal(err)
 		}
-
+		if err := rr.TestHasHeader("Last-Modified"); err != nil {
+			t.Fatal(err)
+		}
+		if err := rr.TestHasHeader("Etag"); err != nil {
+			t.Fatal(err)
+		}
+		if err := rr.TestHasHeader("Expires"); err != nil {
+			t.Fatal(err)
+		}
 		return rr
 
 	}

--- a/rst.go
+++ b/rst.go
@@ -14,8 +14,9 @@ add features.
 Endpoints can implement Getter, Poster, Patcher, Putter or Deleter to
 respectively allow the HEAD/GET, POST, PATCH, PUT, and DELETE HTTP methods.
 
-Resources can implement Ranger to support partial GET requests, or Marshaler to
-customize the process with which they are encoded.
+Resources can implement Ranger to support partial GET requests, Marshaler to
+customize the process with which they are encoded, or http.Handler to have a
+complete control over the ResponseWriter.
 
 With these interfaces, the complexity behind dealing with all the headers and
 status codes of the HTTP protocol is abstracted to let you focus on returning a

--- a/rst_test.go
+++ b/rst_test.go
@@ -35,6 +35,13 @@ func (rr *requestResponse) TestStatusCode(code int) error {
 	return nil
 }
 
+func (rr *requestResponse) TestHasHeader(key string) error {
+	if _, exists := rr.resp.Header[http.CanonicalHeaderKey(key)]; !exists {
+		return fmt.Errorf("expected to find header %s", key)
+	}
+	return nil
+}
+
 func (rr *requestResponse) TestHeader(key, value string) error {
 	if rr.err != nil {
 		return rr.err


### PR DESCRIPTION
Several previously unsupported scenarios are now possible. Also added ErrorHandler to turn any error into an http.Handler